### PR TITLE
Link Kivai product pack to technical repository

### DIFF
--- a/kivai/README.md
+++ b/kivai/README.md
@@ -45,6 +45,15 @@ Any commercial manufacturing, distribution, or commercial exploitation requires 
 
 Unauthorized commercial use is prohibited.
 
+
 ---
+
+## Canonical Technical Repository
+
+The official technical implementation of Kivai (schema, SDK, tests, reference tooling) is maintained in:
+
+https://github.com/tech4life-beyond/kivai
+
+This Product Pack repository contains the TOIL registration, ethics framework, and licensing readiness documentation for the Kivai Platform.
 
 **End of README — T4L-TOIL-002-KIVAI**


### PR DESCRIPTION
- Add canonical reference to the official Kivai technical repository
- Clarify separation between product pack (legal layer) and implementation layer
- Establish structural alignment between products/ and kivai repo