### PR TITLE
Normalize Clean Drain Device IDs and license wording

### DIFF
--- a/clean-drain-device/01-toil-registration/T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/01-toil-registration/T4L-TOIL-001-CDD.md
@@ -1,8 +1,8 @@
 # TOIL Registration Record
 
-**Product ID:** T4L-2025-001  
+**Product ID:** T4L-TOIL-001-CDD  
+**Legacy IDs:** T4L-2025-001  
 **Product Name:** Clean Drain Device  
-**Alternate Name:** DrainClean T Adapter  
 **Company:** Tech4Life & Beyond LLC (Florida, USA)  
 **License:** Tech4Life Open Impact License (TOIL) v1.0  
 **Initial TOIL Registration Date:** 2026-02-01
@@ -12,8 +12,9 @@
 ## 1. Product Identification
 
 - **Official Product Name:** Clean Drain Device  
-- **Alternate / Legacy Name:** DrainClean T Adapter  
-- **TOIL Product ID:** T4L-2025-001  
+- **Aliases:** DrainClean T Adapter  
+- **TOIL Product ID:** T4L-TOIL-001-CDD  
+- **Legacy IDs:** T4L-2025-001  
 - **Product Category:** HVAC Hardware – Preventative Maintenance Device  
 - **TOIL Version:** v1.0
 
@@ -26,7 +27,7 @@ This document constitutes the official TOIL registration of the product listed a
 - **Original Inventor:** Ariel Martin  
 - **Governing Entity:** Tech4Life & Beyond LLC
 
-This product is created, published, and governed under the Tech4Life Open Impact License (TOIL).
+This product is created, published, and governed under the Tech4Life Open Impact License (TOIL) v1.0.
 
 All rights are **licensed, not sold**. No exclusive intellectual property claims are granted under this framework.
 
@@ -132,5 +133,4 @@ This record establishes clear seeable origin, intent, and licensing conditions f
 
 ---
 
-**End of TOIL Registration Record — Product T4L-2025-001**
-
+**End of TOIL Registration Record — Product T4L-TOIL-001-CDD**

--- a/clean-drain-device/03-ethics-statement/Ethics_Statement_T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/03-ethics-statement/Ethics_Statement_T4L-TOIL-001-CDD.md
@@ -1,8 +1,8 @@
 # Ethics & Responsibility Statement
 
-**Product ID:** T4L-2025-001  
+**Product ID:** T4L-TOIL-001-CDD  
+**Legacy IDs:** T4L-2025-001  
 **Product Name:** Clean Drain Device  
-**Alternate Name:** DrainClean T Adapter  
 **Company:** Tech4Life & Beyond LLC  
 **License Framework:** Tech4Life Open Impact License (TOIL) v1.0
 
@@ -121,5 +121,4 @@ Any updates must preserve the original ethical intent and preventative purpose o
 
 ---
 
-**End of Ethics & Responsibility Statement — Product T4L-2025-001**
-
+**End of Ethics & Responsibility Statement — Product T4L-TOIL-001-CDD**

--- a/clean-drain-device/04-licensing-readiness/Licensing_Readiness_T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/04-licensing-readiness/Licensing_Readiness_T4L-TOIL-001-CDD.md
@@ -2,7 +2,7 @@
 
 **Product:** Clean Drain Device  
 **Company:** Tech4Life & Beyond LLC  
-**License Framework:** TOIL – Tech4Life Open Impact License v1.0  
+**License Framework:** Tech4Life Open Impact License (TOIL) v1.0  
 **Status:** Ready for Licensing Evaluation
 
 ---
@@ -147,4 +147,3 @@ Email: info@tech4lifeandbeyond.com
 - Ethical framework documented
 - Licensing pathway clear
 - Ready for manufacturer outreach under TOIL
-

--- a/clean-drain-device/05-sell-sheet/Sell_Sheet_T4L-TOIL-001-CDD_v2.1.md
+++ b/clean-drain-device/05-sell-sheet/Sell_Sheet_T4L-TOIL-001-CDD_v2.1.md
@@ -4,20 +4,12 @@
 
 ---
 
-<!-- Product Image -->
-<!-- Product Image -->
-![Clean Drain Device – DrainClean T Adapter](Sell%20Sheet.png)
-
-*Clean Drain Device (DrainClean T Adapter) – functional diagram showing ports, valve, sensor, and flow direction.*
-
----
-
-
 # Clean Drain Device
 
-**TOIL Product ID:** T4L-2025-001  
+**TOIL Product ID:** T4L-TOIL-001-CDD  
+**Legacy IDs:** T4L-2025-001  
 **Company:** Tech4Life & Beyond LLC  
-**License:** Tech4Life Open Impact License (TOIL)
+**License:** Tech4Life Open Impact License (TOIL) v1.0
 
 ---
 
@@ -105,7 +97,7 @@ Detailed technical specifications are available upon request.
 
 ## Licensing Model (TOIL)
 
-The Clean Drain Device is licensed under the **Tech4Life Open Impact License (TOIL)**.
+The Clean Drain Device is licensed under the **Tech4Life Open Impact License (TOIL) v1.0**.
 
 ### Non-Commercial Use
 - Permitted with attribution
@@ -148,4 +140,3 @@ Email: info@tech4lifeandbeyond.com
 
 **Clean Drain Device**  
 *Prevent damage. Enable visibility. Simplify maintenance.*
-

--- a/clean-drain-device/05-sell-sheet/archive/Sell_Sheet_v2.md
+++ b/clean-drain-device/05-sell-sheet/archive/Sell_Sheet_v2.md
@@ -1,8 +1,9 @@
 # Clean Drain Device
 
-**TOIL Product ID:** T4L-2025-001  
+**TOIL Product ID:** T4L-TOIL-001-CDD  
+**Legacy IDs:** T4L-2025-001  
 **Company:** Tech4Life & Beyond LLC  
-**License:** Tech4Life Open Impact License (TOIL)
+**License:** Tech4Life Open Impact License (TOIL) v1.0
 
 ---
 
@@ -90,7 +91,7 @@ Detailed technical specifications are available upon request.
 
 ## Licensing Model (TOIL)
 
-The Clean Drain Device is licensed under the **Tech4Life Open Impact License (TOIL)**.
+The Clean Drain Device is licensed under the **Tech4Life Open Impact License (TOIL) v1.0**.
 
 ### Non-Commercial Use
 - Permitted with attribution
@@ -133,4 +134,3 @@ Email: info@tech4lifeandbeyond.com
 
 **Clean Drain Device**  
 *Prevent damage. Enable visibility. Simplify maintenance.*
-

--- a/clean-drain-device/07-prototype-status/Prototype_Status_Framework_T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/07-prototype-status/Prototype_Status_Framework_T4L-TOIL-001-CDD.md
@@ -2,6 +2,7 @@
 
 **Product Name:** Clean Drain Device  
 **Product ID:** T4L-TOIL-001-CDD  
+**Legacy IDs:** T4L-2025-001  
 **TOIL Version:** v1.0  
 **Document Version:** 1.0  
 **Last Updated:** 2026-02-04

--- a/clean-drain-device/08-royalty/Royalty_Model_T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/08-royalty/Royalty_Model_T4L-TOIL-001-CDD.md
@@ -2,6 +2,7 @@
 
 **Product Name:** Clean Drain Device  
 **Product ID:** T4L-TOIL-001-CDD  
+**Legacy IDs:** T4L-2025-001  
 **TOIL Version:** v1.0  
 **Document Version:** 1.0  
 **Last Updated:** 2026-02-04
@@ -10,7 +11,7 @@
 
 ## 1. Purpose
 
-This document defines the royalty structure and distribution logic for the Clean Drain Device under the Tech4Life Open Impact License (TOIL).
+This document defines the royalty structure and distribution logic for the Clean Drain Device under the Tech4Life Open Impact License (TOIL) v1.0.
 
 This document establishes the internal royalty allocation model. Final commercial percentages are determined through individual Royalty Agreements with licensed manufacturers or distributors.
 

--- a/clean-drain-device/README.md
+++ b/clean-drain-device/README.md
@@ -1,6 +1,7 @@
 # Clean Drain Device
 
 **TOIL Product ID:** T4L-TOIL-001-CDD  
+**Legacy IDs:** T4L-2025-001  
 **License:** Tech4Life Open Impact License (TOIL) v1.0  
 **Status:** Licensing Ready  
 **Prototype Status:** Pre-Prototype Engineering Phase  


### PR DESCRIPTION
### Motivation
- Ensure the Clean Drain Device documentation uses the canonical TOIL product identifier and preserves prior identifiers for traceability.
- Remove deprecated naming fields and normalize alias/licensing terminology to a consistent, machine-parseable format.
- Prevent a broken image reference from appearing in the sell sheet when the linked file is not present.

### Description
- Replaced legacy `T4L-2025-001` canonical usages with `T4L-TOIL-001-CDD` in the Clean Drain Device pack and added `Legacy IDs: T4L-2025-001` next to the ID fields in each document under `clean-drain-device` (files updated include `01-toil-registration`, `03-ethics-statement`, `05-sell-sheet` and its `archive`, `07-prototype-status`, `08-royalty`, and `README.md`).
- Removed all `Alternate Name` fields and replaced the former `Alternate / Legacy Name` entry with `Aliases` (applied in the registration and related docs). 
- Standardized license wording to `Tech4Life Open Impact License (TOIL) v1.0` across sell sheets and licensing documents. 
- Removed the missing Sell Sheet image reference from `05-sell-sheet/Sell_Sheet_T4L-TOIL-001-CDD_v2.1.md` to avoid a broken image link.

### Testing
- Located and validated occurrences before/after edits using automated searches (`rg`) and inspected file contents with `sed`/`nl`, and these checks confirmed the expected replacements completed successfully. 
- Verified repository state with `git status`, staged the edits, and created a commit which succeeded (`git commit` returned success). 
- Opened a pull request via the repo automation with title and body; no runtime unit tests were required because changes are documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ed2c7fe4832db443e7d22705a90a)