### PR TITLE
Enforce Product Pack validation via CI

### DIFF
--- a/.github/workflows/product-pack-validation.yml
+++ b/.github/workflows/product-pack-validation.yml
@@ -1,0 +1,33 @@
+name: Product Pack Validation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate-pack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Fetch validator and rules
+        run: |
+          mkdir -p tools rules
+          curl -fsSL -o tools/t4l_validate_pack.py \
+            https://raw.githubusercontent.com/tech4life-beyond/product-creation-pipeline/main/tools/t4l_validate_pack.py
+          curl -fsSL -o rules/product_pack_rules.yml \
+            https://raw.githubusercontent.com/tech4life-beyond/product-creation-pipeline/main/rules/product_pack_rules.yml
+
+      - name: Validate product pack
+        run: python tools/t4l_validate_pack.py .


### PR DESCRIPTION
### Motivation
- Enforce product pack validation in CI by running the shared validator `tools/t4l_validate_pack.py` with `rules/product_pack_rules.yml` on pull requests and pushes to `main` to ensure packs conform to the product pack rules.

### Description
- Adds `.github/workflows/product-pack-validation.yml` which checks out the repository using `actions/checkout@v4`, sets up Python 3.11 with `actions/setup-python@v5`, installs `pyyaml`, downloads `tools/t4l_validate_pack.py` and `rules/product_pack_rules.yml` from the `tech4life-beyond/product-creation-pipeline` repository, and runs `python tools/t4l_validate_pack.py .` (the job will fail if the validator exits non-zero).

### Testing
- No automated tests were executed locally as part of this change; the new workflow will run automatically on pull requests and pushes to `main` and will fail if `python tools/t4l_validate_pack.py .` returns a non-zero exit code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698934b7e91c832d96effd4a4f0ac205)