### PR TITLE
Fix Product Pack Validation fetch URLs

### DIFF
--- a/.github/workflows/product-pack-validation.yml
+++ b/.github/workflows/product-pack-validation.yml
@@ -25,9 +25,9 @@ jobs:
         run: |
           mkdir -p tools rules
           curl -fsSL -o tools/t4l_validate_pack.py \
-            https://raw.githubusercontent.com/tech4life-beyond/product-creation-pipeline/9f3d2b0f4b7f8c1a6e3d5c7b9a2e4f6d1c8b0a5e/tools/t4l_validate_pack.py
+            https://raw.githubusercontent.com/tech4life-beyond/product-creation-pipeline/main/tools/t4l_validate_pack.py
           curl -fsSL -o rules/product_pack_rules.yml \
-            https://raw.githubusercontent.com/tech4life-beyond/product-creation-pipeline/9f3d2b0f4b7f8c1a6e3d5c7b9a2e4f6d1c8b0a5e/rules/product_pack_rules.yml
+            https://raw.githubusercontent.com/tech4life-beyond/product-creation-pipeline/main/rules/product_pack_rules.yml
 
       - name: Fetch product registry export
         run: |


### PR DESCRIPTION
### Motivation
- Replace workflow URLs that referenced an invalid SHA with stable `main` branch URLs so the product pack validation job can reliably fetch the validator script and rules.

### Description
- Updated `.github/workflows/product-pack-validation.yml` to fetch `tools/t4l_validate_pack.py` and `rules/product_pack_rules.yml` from `https://raw.githubusercontent.com/tech4life-beyond/product-creation-pipeline/main/...` instead of the broken SHA-based raw GitHub URLs.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a3139461c832d8e5e220e506299a2)