### PR TITLE
Fix duplicated Category metadata in CDD README

### DIFF
--- a/clean-drain-device/01-toil-registration/T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/01-toil-registration/T4L-TOIL-001-CDD.md
@@ -134,5 +134,4 @@ This record establishes clear seeable origin, intent, and licensing conditions f
 ---
 
 **End of TOIL Registration Record — Product T4L-TOIL-001-CDD**
-> Registry sync test marker.
-TOIL Registry Note: sync-test-2026-02-10
+

--- a/clean-drain-device/README.md
+++ b/clean-drain-device/README.md
@@ -87,5 +87,4 @@ Email: tech4lifeandbeyond@gmail.com
 ---
 
 **End of Product README – T4L-TOIL-001-CDD**
-Category: Plumbing
-<!-- dispatch-test-2 -->
+


### PR DESCRIPTION
Remove stray Category line and dispatch test marker to keep registry generation consistent in CDD README and T4L-TOIL-001-CDD.md.