### PR TITLE
Harden products: redact royalty split, pin GH Actions, add git hygiene

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto eol=lf
+
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.txt text eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.pdf binary
+*.zip binary

--- a/.github/workflows/product-pack-validation.yml
+++ b/.github/workflows/product-pack-validation.yml
@@ -17,24 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 :contentReference[oaicite:1]{index=1}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Checkout pipeline (pinned)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 :contentReference[oaicite:2]{index=2}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: tech4life-beyond/product-creation-pipeline
           ref: v1.0.0
           path: .ci/pipeline
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0 :contentReference[oaicite:3]{index=3}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.11'
 
       - name: Install validator dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install "pyyaml==6.0.3" :contentReference[oaicite:4]{index=4}
+          python3 -m pip install "pyyaml==6.0.3"
 
       - name: Run product pack validator
         run: |

--- a/.github/workflows/product-pack-validation.yml
+++ b/.github/workflows/product-pack-validation.yml
@@ -17,24 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 :contentReference[oaicite:1]{index=1}
 
       - name: Checkout pipeline (pinned)
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 :contentReference[oaicite:2]{index=2}
         with:
           repository: tech4life-beyond/product-creation-pipeline
           ref: v1.0.0
           path: .ci/pipeline
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0 :contentReference[oaicite:3]{index=3}
         with:
           python-version: '3.11'
 
       - name: Install validator dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install pyyaml
+          python3 -m pip install "pyyaml==6.0.3" :contentReference[oaicite:4]{index=4}
 
       - name: Run product pack validator
         run: |

--- a/.github/workflows/trigger-registry-sync.yml
+++ b/.github/workflows/trigger-registry-sync.yml
@@ -13,12 +13,11 @@ concurrency:
 
 jobs:
   dispatch:
-    # Prevent infinite loops if a bot updates the repo
     if: ${{ !endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch sync event to product-registry
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1 :contentReference[oaicite:6]{index=6}
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
         with:
           token: ${{ secrets.REGISTRY_DISPATCH_TOKEN }}
           repository: tech4life-beyond/product-registry

--- a/.github/workflows/trigger-registry-sync.yml
+++ b/.github/workflows/trigger-registry-sync.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch sync event to product-registry
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1 :contentReference[oaicite:6]{index=6}
         with:
           token: ${{ secrets.REGISTRY_DISPATCH_TOKEN }}
           repository: tech4life-beyond/product-registry

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# OS / Editor
+.DS_Store
+Thumbs.db
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.env
+
+# Logs
+*.log
+
+# Node
+node_modules/
+
+# Build artifacts
+dist/
+build/

--- a/clean-drain-device/08-royalty/Royalty_Model_T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/08-royalty/Royalty_Model_T4L-TOIL-001-CDD.md
@@ -1,10 +1,10 @@
 # Royalty Model Document
 
-**Product Name:** Clean Drain Device  
-**Product ID:** T4L-TOIL-001-CDD  
-**Legacy IDs:** T4L-2025-001  
-**TOIL Version:** v1.0  
-**Document Version:** 1.0  
+**Product Name:** Clean Drain Device
+**Product ID:** T4L-TOIL-001-CDD
+**Legacy IDs:** T4L-2025-001
+**TOIL Version:** v1.0
+**Document Version:** 1.0
 **Last Updated:** 2026-02-04
 
 ---
@@ -29,7 +29,7 @@ Commercial use without agreement is prohibited.
 
 Unless otherwise negotiated, the default structure is:
 
-**Royalty Base:** Net Sales Revenue  
+**Royalty Base:** Net Sales Revenue
 (Net sales = Gross revenue minus returns, refunds, and approved distribution costs)
 
 **Royalty Range:** 3%–8% of Net Sales
@@ -44,32 +44,13 @@ Final percentage is negotiated based on:
 
 ---
 
-## 4. Internal Royalty Allocation Framework
+## 4. Internal Royalty Allocation Framework (Redacted — Public)
 
-When royalty revenue is received by Tech4Life & Beyond LLC, distribution follows this model unless otherwise defined in a specific Collaboration Agreement.
+Tech4Life & Beyond LLC maintains an internal royalty allocation framework to distribute proceeds to contributors and to sustain operations.
 
-### A. Creator Allocation
+**Public note:** Specific internal allocation percentages, contributor splits, and distribution mechanics are **Confidential** and are maintained in private internal repositories. They are finalized per product and may vary based on contribution records and collaboration agreements.
 
-If developed by a Product Cell:
-
-- 60% allocated to Product Cell contributors
-- Distributed proportionally based on documented contribution level
-
-If single inventor:
-
-- Allocation defined by founder decision under internal governance
-
-### B. Company Allocation
-
-- 40% retained by Tech4Life & Beyond LLC
-
-Used for:
-
-- Operational costs
-- Legal protection
-- Platform infrastructure
-- New product incubation
-- Community growth
+For external licensing, the only binding commercial terms are those defined in the signed TOIL Royalty Agreement with the licensee.
 
 ---
 


### PR DESCRIPTION
Redacts internal royalty allocation details from the public Clean Drain Device pack.

Pins GitHub Actions by commit SHA (checkout, setup-python, repository-dispatch) to reduce supply-chain risk.

Pins PyYAML dependency used by the validator workflow.

Adds .gitignore and .gitattributes to standardize repo hygiene and line endings.

## Summary
- What changed:
- Why it changed:

## Impact classification
- [ ] breaking
- [ ] additive
- [ ] editorial

## Product Pack checklist (required)
- [ ] Product Pack requirements satisfied (docs present / N/A justified)
- [ ] IDs and filenames match the registry and templates
- [ ] No sensitive data added (royalty, private terms) without classification
- [ ] CI validation passes

## Registry sync (if applicable)
- [ ] This change should trigger sync to `product-registry`
- [ ] This change should NOT trigger sync (explain why)

## Notes
