### PR TITLE
fix(products): add KIVAI technical summary and normalize LF line endings

### DIFF
--- a/clean-drain-device/01-toil-registration/T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/01-toil-registration/T4L-TOIL-001-CDD.md
@@ -1,21 +1,21 @@
 # TOIL Registration Record
 
-**Product ID:** T4L-TOIL-001-CDD  
-**Legacy IDs:** T4L-2025-001  
-**Product Name:** Clean Drain Device  
-**Company:** Tech4Life & Beyond LLC (Florida, USA)  
-**License:** Tech4Life Open Impact License (TOIL) v1.0  
+**Product ID:** T4L-TOIL-001-CDD
+**Legacy IDs:** T4L-2025-001
+**Product Name:** Clean Drain Device
+**Company:** Tech4Life & Beyond LLC (Florida, USA)
+**License:** Tech4Life Open Impact License (TOIL) v1.0
 **Initial TOIL Registration Date:** 2026-02-01
 
 ---
 
 ## 1. Product Identification
 
-- **Official Product Name:** Clean Drain Device  
-- **Aliases:** DrainClean T Adapter  
-- **TOIL Product ID:** T4L-TOIL-001-CDD  
-- **Legacy IDs:** T4L-2025-001  
-- **Product Category:** HVAC Hardware – Preventative Maintenance Device  
+- **Official Product Name:** Clean Drain Device
+- **Aliases:** DrainClean T Adapter
+- **TOIL Product ID:** T4L-TOIL-001-CDD
+- **Legacy IDs:** T4L-2025-001
+- **Product Category:** HVAC Hardware – Preventative Maintenance Device
 - **TOIL Version:** v1.0
 
 This document constitutes the official TOIL registration of the product listed above.
@@ -24,7 +24,7 @@ This document constitutes the official TOIL registration of the product listed a
 
 ## 2. Ownership & Authorship
 
-- **Original Inventor:** Ariel Martin  
+- **Original Inventor:** Ariel Martin
 - **Governing Entity:** Tech4Life & Beyond LLC
 
 This product is created, published, and governed under the Tech4Life Open Impact License (TOIL) v1.0.

--- a/clean-drain-device/03-ethics-statement/Ethics_Statement_T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/03-ethics-statement/Ethics_Statement_T4L-TOIL-001-CDD.md
@@ -1,9 +1,9 @@
 # Ethics & Responsibility Statement
 
-**Product ID:** T4L-TOIL-001-CDD  
-**Legacy IDs:** T4L-2025-001  
-**Product Name:** Clean Drain Device  
-**Company:** Tech4Life & Beyond LLC  
+**Product ID:** T4L-TOIL-001-CDD
+**Legacy IDs:** T4L-2025-001
+**Product Name:** Clean Drain Device
+**Company:** Tech4Life & Beyond LLC
 **License Framework:** Tech4Life Open Impact License (TOIL) v1.0
 
 ---

--- a/clean-drain-device/04-licensing-readiness/Licensing_Readiness_T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/04-licensing-readiness/Licensing_Readiness_T4L-TOIL-001-CDD.md
@@ -1,8 +1,8 @@
 # Licensing-Readiness – Clean Drain Device
 
-**Product:** Clean Drain Device  
-**Company:** Tech4Life & Beyond LLC  
-**License Framework:** Tech4Life Open Impact License (TOIL) v1.0  
+**Product:** Clean Drain Device
+**Company:** Tech4Life & Beyond LLC
+**License Framework:** Tech4Life Open Impact License (TOIL) v1.0
 **Status:** Ready for Licensing Evaluation
 
 ---
@@ -83,7 +83,7 @@ Tech4Life & Beyond LLC:
 
 All licensed products must include:
 - The Tech4Life & Beyond logo (placement defined in agreement)
-- Attribution statement:  
+- Attribution statement:
   **“Created by Tech4Life & Beyond LLC – Licensed under TOIL.”**
 - Reference to the TOIL License in documentation or packaging
 
@@ -135,8 +135,8 @@ Ethical violations constitute material breach of license.
 
 All licensing inquiries must be directed to:
 
-**Tech4Life & Beyond LLC**  
-Website: https://tech4lifeandbeyond.com  
+**Tech4Life & Beyond LLC**
+Website: https://tech4lifeandbeyond.com
 Email: info@tech4lifeandbeyond.com
 
 ---

--- a/clean-drain-device/05-sell-sheet/Sell_Sheet_T4L-TOIL-001-CDD_v2.1.md
+++ b/clean-drain-device/05-sell-sheet/Sell_Sheet_T4L-TOIL-001-CDD_v2.1.md
@@ -6,9 +6,9 @@
 
 # Clean Drain Device
 
-**TOIL Product ID:** T4L-TOIL-001-CDD  
-**Legacy IDs:** T4L-2025-001  
-**Company:** Tech4Life & Beyond LLC  
+**TOIL Product ID:** T4L-TOIL-001-CDD
+**Legacy IDs:** T4L-2025-001
+**Company:** Tech4Life & Beyond LLC
 **License:** Tech4Life Open Impact License (TOIL) v1.0
 
 ---
@@ -132,11 +132,11 @@ Licensing is **ethical, non-exclusive, and scalable**.
 
 ## Licensing Contact
 
-**Tech4Life & Beyond LLC**  
-Website: https://tech4lifeandbeyond.com  
+**Tech4Life & Beyond LLC**
+Website: https://tech4lifeandbeyond.com
 Email: info@tech4lifeandbeyond.com
 
 ---
 
-**Clean Drain Device**  
+**Clean Drain Device**
 *Prevent damage. Enable visibility. Simplify maintenance.*

--- a/clean-drain-device/05-sell-sheet/archive/Sell_Sheet_v2.md
+++ b/clean-drain-device/05-sell-sheet/archive/Sell_Sheet_v2.md
@@ -1,8 +1,8 @@
 # Clean Drain Device
 
-**TOIL Product ID:** T4L-TOIL-001-CDD  
-**Legacy IDs:** T4L-2025-001  
-**Company:** Tech4Life & Beyond LLC  
+**TOIL Product ID:** T4L-TOIL-001-CDD
+**Legacy IDs:** T4L-2025-001
+**Company:** Tech4Life & Beyond LLC
 **License:** Tech4Life Open Impact License (TOIL) v1.0
 
 ---
@@ -126,11 +126,11 @@ Licensing is **ethical, non-exclusive, and scalable**.
 
 ## Licensing Contact
 
-**Tech4Life & Beyond LLC**  
-Website: https://tech4lifeandbeyond.com  
+**Tech4Life & Beyond LLC**
+Website: https://tech4lifeandbeyond.com
 Email: info@tech4lifeandbeyond.com
 
 ---
 
-**Clean Drain Device**  
+**Clean Drain Device**
 *Prevent damage. Enable visibility. Simplify maintenance.*

--- a/clean-drain-device/07-prototype-status/Prototype_Status_Framework_T4L-TOIL-001-CDD.md
+++ b/clean-drain-device/07-prototype-status/Prototype_Status_Framework_T4L-TOIL-001-CDD.md
@@ -1,10 +1,10 @@
 # Prototype Status Document
 
-**Product Name:** Clean Drain Device  
-**Product ID:** T4L-TOIL-001-CDD  
-**Legacy IDs:** T4L-2025-001  
-**TOIL Version:** v1.0  
-**Document Version:** 1.0  
+**Product Name:** Clean Drain Device
+**Product ID:** T4L-TOIL-001-CDD
+**Legacy IDs:** T4L-2025-001
+**TOIL Version:** v1.0
+**Document Version:** 1.0
 **Last Updated:** 2026-02-04
 
 ---
@@ -19,9 +19,9 @@ This document is part of the official Tech4Life Product Pack structure.
 
 ## 2. Current Prototype Status
 
-**Physical Prototype:** Not yet manufactured  
-**Functional CAD Model:** Pending  
-**3D Print Test Unit:** Not produced  
+**Physical Prototype:** Not yet manufactured
+**Functional CAD Model:** Pending
+**3D Print Test Unit:** Not produced
 **Electromechanical Integration:** Conceptual stage
 
 The product is currently in the pre-prototype phase.

--- a/kivai/01-toil-registration/TOIL_Registration_T4L-TOIL-002-KIVAI.md
+++ b/kivai/01-toil-registration/TOIL_Registration_T4L-TOIL-002-KIVAI.md
@@ -1,11 +1,11 @@
 # TOIL Registration Record — Kivai
 
-**Product Name:** Kivai  
-**Product ID:** T4L-TOIL-002-KIVAI  
-**Classification:** Platform Infrastructure (Software / Interoperability Standard)  
-**TOIL Version:** v1.0  
-**Document Version:** 1.0  
-**Last Updated:** 2026-02-05  
+**Product Name:** Kivai
+**Product ID:** T4L-TOIL-002-KIVAI
+**Classification:** Platform Infrastructure (Software / Interoperability Standard)
+**TOIL Version:** v1.0
+**Document Version:** 1.0
+**Last Updated:** 2026-02-05
 **Entity:** Tech4Life & Beyond LLC (Florida, USA)
 
 ---

--- a/kivai/02-technical-summary/Technical_Summary_T4L-TOIL-002-KIVAI.md
+++ b/kivai/02-technical-summary/Technical_Summary_T4L-TOIL-002-KIVAI.md
@@ -1,0 +1,175 @@
+# Technical Summary
+## KIVAI (Intent Gateway & Interoperability Layer)
+
+---
+
+## 1. Overview
+
+**KIVAI** is a schema-first, deterministic interoperability platform that routes **canonical Intent JSON** into authorized actions across physical and digital devices.
+
+KIVAI is:
+
+- **not** a chatbot or assistant
+- **not** a UI product
+- **not** a product registry
+
+KIVAI is an **execution gateway**:
+
+AI / UI / Button → Intent JSON → KIVAI → Adapter → Device → ACK + audit log
+
+---
+
+## 2. System Context
+
+Modern ecosystems are fragmented:
+
+- voice assistants are proprietary
+- devices use different protocols (Wi-Fi, BLE, Zigbee, IR, HTTP, MQTT)
+- “smart home” logic is inconsistent and hard to audit
+
+KIVAI introduces a unified, auditable layer so any front-end can trigger consistent, authorized execution.
+
+---
+
+## 3. Core Architecture
+
+### 3.1 Canonical Intent Contract
+
+KIVAI defines a canonical **Intent JSON** schema (contract-first).
+
+The schema enables:
+
+- validation before execution
+- consistent routing fields (device_id / capability / zone)
+- traceability metadata (timestamp, language, confidence, request_id)
+
+---
+
+### 3.2 Validation & Normalization
+
+Before any action is executed, KIVAI:
+
+- validates the intent against the schema
+- normalizes fields into a deterministic form
+- rejects malformed or incomplete intents
+
+---
+
+### 3.3 Authorization & Policy
+
+KIVAI enforces:
+
+- authentication (who is calling)
+- authorization (what they can do)
+- policy gates (ethical / safety constraints where applicable)
+
+Unauthorized intents must be rejected deterministically.
+
+---
+
+### 3.4 Routing Layer
+
+KIVAI routes intents to an execution target by:
+
+- direct `device_id`, or
+- `capability + zone`, resolved via routing rules
+
+Routing produces a deterministic execution plan.
+
+---
+
+### 3.5 Adapter Execution Layer
+
+Execution occurs via **adapters**, which translate intents into device/protocol-specific commands.
+
+Adapters may target:
+
+- Wi-Fi devices (HTTP/REST)
+- BLE devices
+- IR blasters
+- MQTT endpoints
+- microcontrollers (e.g., ESP32 as an endpoint)
+
+Adapters are replaceable and device-agnostic.
+
+---
+
+### 3.6 Acknowledgement & Audit
+
+Every execution produces:
+
+- `execution_id`
+- deterministic ACK response
+- audit record (intent + auth + routing + adapter result)
+
+Auditability is mandatory for safe automation.
+
+---
+
+## 4. Multi-Front-End Model (Voice, App, Button)
+
+KIVAI does not depend on any single input interface.
+
+Typical front-ends include:
+
+- mobile app (sends Intent JSON)
+- physical button / remote (sends Intent JSON through a small gateway)
+- AI system / LLM (produces Intent JSON)
+- voice assistant integrations (future adapters/connectors)
+
+KIVAI remains the stable execution layer regardless of front-end.
+
+---
+
+## 5. Deployment Targets
+
+Recommended deployment model v1.0:
+
+- **Gateway host:** Raspberry Pi / router / local server
+- **Network:** local LAN (Ethernet/Wi-Fi)
+- **Endpoints:** devices or microcontrollers reachable via adapters
+
+This enables practical demonstrations and real-world pilots.
+
+---
+
+## 6. Operational Behavior
+
+### Normal Operation
+
+- intent received
+- schema validated
+- authorization applied
+- routed to adapter
+- device command executed
+- ACK returned with `execution_id`
+- audit logged
+
+### Failure Modes (Deterministic)
+
+- invalid schema → reject with error
+- unauthorized request → reject with error
+- adapter failure → ACK indicates failure + audit captures details
+
+---
+
+## 7. Safety & Reliability Considerations
+
+KIVAI emphasizes:
+
+- deterministic processing (no “guessing” at execution time)
+- auditable traces for accountability
+- policy enforcement before action
+- adapter isolation (failures do not corrupt routing logic)
+
+---
+
+## 8. Technical Scope Statement
+
+This summary describes KIVAI’s functional and architectural characteristics for licensing, deployment, and integration purposes.
+
+Detailed implementation, adapters, and deployment scripts are maintained in the `kivai` repository.
+
+---
+
+**End of Technical Summary — KIVAI**

--- a/kivai/03-ethics-statement/Ethics_Statement_T4L-TOIL-002-KIVAI.md
+++ b/kivai/03-ethics-statement/Ethics_Statement_T4L-TOIL-002-KIVAI.md
@@ -1,10 +1,10 @@
 # Ethics Statement — Kivai
 
-**Product Name:** Kivai  
-**Product ID:** T4L-TOIL-002-KIVAI  
-**TOIL Version:** v1.0  
-**Document Version:** 1.0  
-**Last Updated:** 2026-02-05  
+**Product Name:** Kivai
+**Product ID:** T4L-TOIL-002-KIVAI
+**TOIL Version:** v1.0
+**Document Version:** 1.0
+**Last Updated:** 2026-02-05
 **Entity:** Tech4Life & Beyond LLC (Florida, USA)
 
 ---

--- a/kivai/04-licensing-readiness/Licensing_Readiness_T4L-TOIL-002-KIVAI.md
+++ b/kivai/04-licensing-readiness/Licensing_Readiness_T4L-TOIL-002-KIVAI.md
@@ -1,11 +1,11 @@
 # Licensing Readiness — Kivai
 
-**Product Name:** Kivai  
-**Product ID:** T4L-TOIL-002-KIVAI  
-**Classification:** Platform Infrastructure (Software / Interoperability Standard)  
-**TOIL Version:** v1.0  
-**Document Version:** 1.0  
-**Last Updated:** 2026-02-05  
+**Product Name:** Kivai
+**Product ID:** T4L-TOIL-002-KIVAI
+**Classification:** Platform Infrastructure (Software / Interoperability Standard)
+**TOIL Version:** v1.0
+**Document Version:** 1.0
+**Last Updated:** 2026-02-05
 **Entity:** Tech4Life & Beyond LLC (Florida, USA)
 
 ---

--- a/kivai/README.md
+++ b/kivai/README.md
@@ -10,10 +10,10 @@ Status: Active
 
 License State: Open for Licensing
 
-**Product ID:** T4L-TOIL-002-KIVAI  
-**Classification:** Platform Infrastructure (Software / Interoperability Standard)  
-**License:** Tech4Life Open Impact License (TOIL) v1.0  
-**Entity:** Tech4Life & Beyond LLC (Florida, USA)  
+**Product ID:** T4L-TOIL-002-KIVAI
+**Classification:** Platform Infrastructure (Software / Interoperability Standard)
+**License:** Tech4Life Open Impact License (TOIL) v1.0
+**Entity:** Tech4Life & Beyond LLC (Florida, USA)
 **Status:** Platform Foundation — In Development
 
 ---
@@ -29,7 +29,7 @@ Kivai is the execution and interoperability layer between AI systems and device 
 
 ## Repositories
 
-**Technical platform repository (code, schema, SDK, CI):**  
+**Technical platform repository (code, schema, SDK, CI):**
 - tech4life-beyond/kivai
 
 This Product Pack provides the official documentation required for TOIL alignment, ethics, and licensing readiness.
@@ -38,13 +38,13 @@ This Product Pack provides the official documentation required for TOIL alignmen
 
 ## Documentation Structure
 
-- **01-toil-registration/**  
+- **01-toil-registration/**
   Official platform registration record under TOIL.
 
-- **03-ethics-statement/**  
+- **03-ethics-statement/**
   Ethical commitments, safety principles, and non-harm alignment.
 
-- **04-licensing-readiness/**  
+- **04-licensing-readiness/**
   Commercial positioning and licensing readiness for industrial partners.
 
 ---


### PR DESCRIPTION
Adds the missing 02-technical-summary documentation for the KIVAI Product Pack to satisfy validation rules and normalizes line endings to LF for cross-platform consistency.

## Summary
- What changed:
- Why it changed:

## Impact classification
- [ ] breaking
- [ ] additive
- [ ] editorial

## Product Pack checklist (required)
- [ ] Product Pack requirements satisfied (docs present / N/A justified)
- [ ] IDs and filenames match the registry and templates
- [ ] No sensitive data added (royalty, private terms) without classification
- [ ] CI validation passes

## Registry sync (if applicable)
- [ ] This change should trigger sync to `product-registry`
- [ ] This change should NOT trigger sync (explain why)

## Notes
