### PR TITLE
Align Kivai product pack README with actual pack structure

### DIFF
--- a/kivai/README.md
+++ b/kivai/README.md
@@ -41,6 +41,9 @@ This Product Pack provides the official documentation required for TOIL alignmen
 - **01-toil-registration/**
   Official platform registration record under TOIL.
 
+- **02-technical-summary/**
+  Technical summary of the platform, including scope, architecture overview, and canonical technical references.
+
 - **03-ethics-statement/**
   Ethical commitments, safety principles, and non-harm alignment.
 
@@ -54,7 +57,6 @@ This Product Pack provides the official documentation required for TOIL alignmen
 Any commercial manufacturing, distribution, or commercial exploitation requires a signed TOIL Royalty Agreement with Tech4Life & Beyond LLC.
 
 Unauthorized commercial use is prohibited.
-
 
 ---
 


### PR DESCRIPTION
Add missing 02-technical-summary section to Documentation Structure

No functional changes; documentation alignment only

## Summary
- What changed:
- Why it changed:

## Impact classification
- [ ] breaking
- [ ] additive
- [ ] editorial

## Product Pack checklist (required)
- [ ] Product Pack requirements satisfied (docs present / N/A justified)
- [ ] IDs and filenames match the registry and templates
- [ ] No sensitive data added (royalty, private terms) without classification
- [ ] CI validation passes

## Registry sync (if applicable)
- [ ] This change should trigger sync to `product-registry`
- [ ] This change should NOT trigger sync (explain why)

## Notes
